### PR TITLE
Port batch

### DIFF
--- a/src/cat_play.rs
+++ b/src/cat_play.rs
@@ -14,7 +14,8 @@ use crate::{
     pcrlib_a_state::PcrlibAState,
     pcrlib_c::{
         centerwindow, get, print, printint, printlong, ControlPlayer, UpdateScreen, _inputint,
-        bioskey, clearkeys, highscores, keydown, level, score, sx, sy, RecordDemo, SaveDemo,
+        bioskey, clearkeys, highscores, keydown, level, port_temp_SaveDemo, score, sx, sy,
+        RecordDemo,
     },
     scan_codes::*,
     tag_type::tagtype::*,
@@ -1318,7 +1319,7 @@ pub unsafe fn playloop(gs: &mut GlobalState, cps: &mut CpanelState, pas: &mut Pc
                     break;
                 }
             }
-            SaveDemo((ch - '0' as i8) as i32, gs);
+            port_temp_SaveDemo((ch - '0' as i8) as u8, gs);
             clearold(&mut gs.oldtiles);
             refresh(gs, pas);
             refresh(gs, pas);

--- a/src/cat_play.rs
+++ b/src/cat_play.rs
@@ -14,7 +14,7 @@ use crate::{
     pcrlib_a_state::PcrlibAState,
     pcrlib_c::{
         centerwindow, get, print, printint, printlong, ControlPlayer, UpdateScreen, _inputint,
-        bioskey, ch, clearkeys, highscores, keydown, level, score, sx, sy, RecordDemo, SaveDemo,
+        bioskey, clearkeys, highscores, keydown, level, score, sx, sy, RecordDemo, SaveDemo,
     },
     scan_codes::*,
     tag_type::tagtype::*,
@@ -1291,8 +1291,8 @@ pub unsafe fn playloop(gs: &mut GlobalState, cps: &mut CpanelState, pas: &mut Pc
             centerwindow(12, 1, gs);
             print(b"RECORD DEMO\0" as *const u8 as *const i8, gs);
             loop {
-                ch = get(gs, pas) as i8;
-                if !(ch as i32 != 13) {
+                let ch = get(gs, pas) as i8;
+                if !(ch != 13) {
                     break;
                 }
             }
@@ -1311,13 +1311,14 @@ pub unsafe fn playloop(gs: &mut GlobalState, cps: &mut CpanelState, pas: &mut Pc
             clearkeys();
             centerwindow(15, 1, gs);
             print(b"SAVE AS DEMO#:\0" as *const u8 as *const i8, gs);
+            let mut ch;
             loop {
                 ch = get(gs, pas) as i8;
-                if !((ch as i32) < '0' as i32 || ch as i32 > '9' as i32) {
+                if !(ch < '0' as i8 || ch > '9' as i8) {
                     break;
                 }
             }
-            SaveDemo(ch as i32 - '0' as i32, gs);
+            SaveDemo((ch - '0' as i8) as i32, gs);
             clearold(&mut gs.oldtiles);
             refresh(gs, pas);
             refresh(gs, pas);

--- a/src/cat_play.rs
+++ b/src/cat_play.rs
@@ -14,8 +14,7 @@ use crate::{
     pcrlib_a_state::PcrlibAState,
     pcrlib_c::{
         centerwindow, get, print, printint, printlong, ControlPlayer, UpdateScreen, _inputint,
-        bioskey, clearkeys, highscores, keydown, level, port_temp_SaveDemo, score, sx, sy,
-        RecordDemo,
+        bioskey, clearkeys, highscores, keydown, level, score, sx, sy, RecordDemo, SaveDemo,
     },
     scan_codes::*,
     tag_type::tagtype::*,
@@ -1319,7 +1318,7 @@ pub unsafe fn playloop(gs: &mut GlobalState, cps: &mut CpanelState, pas: &mut Pc
                     break;
                 }
             }
-            port_temp_SaveDemo((ch - '0' as i8) as u8, gs);
+            SaveDemo((ch - '0' as i8) as u8, gs);
             clearold(&mut gs.oldtiles);
             refresh(gs, pas);
             refresh(gs, pas);

--- a/src/catacomb.rs
+++ b/src/catacomb.rs
@@ -33,8 +33,8 @@ use crate::{
     pcrlib_a_state::PcrlibAState,
     pcrlib_c::{
         ControlPlayer, LoadDemo, UpdateScreen, _Verify, _checkhighscore, _quit, _setupgame,
-        _showhighscores, bar, bioskey, bloadin, centerwindow, ch, clearkeys, drawwindow, expwin,
-        get, grmode, keydown, leftedge, level, port_temp_LoadFile, print, printchartile, printint,
+        _showhighscores, bar, bioskey, bloadin, centerwindow, clearkeys, drawwindow, expwin, get,
+        grmode, keydown, leftedge, level, port_temp_LoadFile, print, printchartile, printint,
         score, sx, sy,
     },
     rleasm::port_temp_RLEExpand,
@@ -205,8 +205,8 @@ unsafe fn wantmore(gs: &mut GlobalState, pas: &mut PcrlibAState) -> boolean {
     print(b"(space for more/esc)\0" as *const u8 as *const i8, gs);
     sx = 12;
     sy = 21;
-    ch = get(gs, pas) as i8;
-    if ch as i32 == 27 {
+    let ch = get(gs, pas) as i8;
+    if ch == 27 {
         return false as boolean;
     }
     return true as boolean;
@@ -410,8 +410,8 @@ unsafe fn help(gs: &mut GlobalState, pas: &mut PcrlibAState) {
 unsafe fn reset(gs: &mut GlobalState, pas: &mut PcrlibAState) {
     centerwindow(18, 1, gs);
     print(b"reset game (y/n)?\0" as *const u8 as *const i8, gs);
-    ch = get(gs, pas) as i8;
-    if ch as i32 == 'y' as i32 {
+    let ch = get(gs, pas) as i8;
+    if ch == 'y' as i8 {
         gs.gamexit = killed;
         gs.playdone = true;
     }
@@ -633,7 +633,7 @@ pub unsafe fn dofkeys(gs: &mut GlobalState, cps: &mut CpanelState, pas: &mut Pcr
             clearkeys();
             expwin(18, 1, gs, pas);
             print(b"RESET GAME (Y/N)?\0" as *const u8 as *const i8, gs);
-            ch = (get(gs, pas) as u8).to_ascii_uppercase() as i8;
+            let ch = (get(gs, pas) as u8).to_ascii_uppercase() as i8;
             if ch as i32 == 'Y' as i32 {
                 gs.resetgame = true;
             }
@@ -646,7 +646,7 @@ pub unsafe fn dofkeys(gs: &mut GlobalState, cps: &mut CpanelState, pas: &mut Pcr
                 get(gs, pas);
             } else {
                 print(b"Save as game #(1-9):\0" as *const u8 as *const i8, gs);
-                ch = (get(gs, pas) as u8).to_ascii_uppercase() as i8;
+                let mut ch = (get(gs, pas) as u8).to_ascii_uppercase() as i8;
                 drawchar(sx, sy, ch as i32, gs);
                 if !((ch as i32) < '1' as i32 || ch as i32 > '9' as i32) {
                     let str = CString::new(format!("GAME{ch}.CA2")).unwrap();
@@ -717,7 +717,7 @@ pub unsafe fn dofkeys(gs: &mut GlobalState, cps: &mut CpanelState, pas: &mut Pcr
             clearkeys();
             expwin(22, 4, gs, pas);
             print(b"Load game #(1-9):\0" as *const u8 as *const i8, gs);
-            ch = (get(gs, pas) as u8).to_ascii_uppercase() as i8;
+            let ch = (get(gs, pas) as u8).to_ascii_uppercase() as i8;
             drawchar(sx, sy, ch as i32, gs);
             if !((ch as i32) < '1' as i32 || ch as i32 > '9' as i32) {
                 let str = CString::new(format!("GAME{ch}.CA2")).unwrap();
@@ -772,8 +772,8 @@ pub unsafe fn dofkeys(gs: &mut GlobalState, cps: &mut CpanelState, pas: &mut Pcr
             clearkeys();
             expwin(12, 1, gs, pas);
             print(b"QUIT (Y/N)?\0" as *const u8 as *const i8, gs);
-            ch = (get(gs, pas) as u8).to_ascii_uppercase() as i8;
-            if ch as i32 == 'Y' as i32 {
+            let ch = (get(gs, pas) as u8).to_ascii_uppercase() as i8;
+            if ch == 'Y' as i8 {
                 _quit(b"\0" as *const u8 as *const i8 as *mut i8, pas);
             }
         }

--- a/src/dir_type.rs
+++ b/src/dir_type.rs
@@ -29,3 +29,9 @@ impl From<u16> for dirtype {
         FromPrimitive::from_u16(value).unwrap()
     }
 }
+
+impl From<u8> for dirtype {
+    fn from(value: u8) -> Self {
+        FromPrimitive::from_u8(value).unwrap()
+    }
+}

--- a/src/pcrlib_c.rs
+++ b/src/pcrlib_c.rs
@@ -933,6 +933,14 @@ pub unsafe fn RecordDemo(gs: &mut GlobalState) {
     gs.indemo = demoenum::recording;
 }
 
+////////////////////////
+//
+// LoadDemo / SaveDemo
+// Loads a demo from disk or
+// saves the accumulated demo command string to disk
+//
+////////////////////////
+
 pub fn LoadDemo(mut demonum: i32, gs: &mut GlobalState) {
     let filename = format!("DEMO{demonum}.{port_temp__extension}");
     let mut temp_port_demobuffer = [0; 5000];
@@ -955,6 +963,22 @@ pub unsafe fn SaveDemo(mut demonum: i32, gs: &mut GlobalState) {
     );
     gs.indemo = demoenum::notdemo;
 }
+
+pub unsafe fn port_temp_SaveDemo(demonum: u8, gs: &mut GlobalState) {
+    let str = format!("DEMO{demonum}.{port_temp__extension}");
+
+    port_temp_SaveFile(&str, &demobuffer[..demoptr]);
+
+    gs.indemo = demoenum::notdemo;
+}
+
+////////////////////////
+//
+// StartDemo
+//
+////////////////////////
+
+/*=========================================================================*/
 
 pub unsafe fn clearkeys() {
     let mut i: i32 = 0;

--- a/src/pcrlib_c.rs
+++ b/src/pcrlib_c.rs
@@ -1753,11 +1753,12 @@ pub unsafe fn _showhighscores(gs: &mut GlobalState) {
         }
         // Rust port: Interesting, if this is passed as format! parameter, it will cause a warning.
         let highscore = highscores[i as usize].level;
-        let str = CString::new(format!("{highscore}")).unwrap();
+        let str = CString::new(highscore.to_string()).unwrap();
         print(str.as_ptr(), gs);
         sx += 1;
         // Rust port: Watch out! Entries includes the cstring terminator, which we must skip!
-        let str = CString::new(&highscores[i as usize].initials.map(|f| f as u8)[0..=2]).unwrap();
+        let highscore_bytes = &highscores[i as usize].initials.map(|f| f as u8)[0..=2];
+        let str = CString::new(highscore_bytes).unwrap();
         print(str.as_ptr(), gs);
         let str = CString::new("\n\n").unwrap();
         print(str.as_ptr(), gs);

--- a/src/pcrlib_c.rs
+++ b/src/pcrlib_c.rs
@@ -524,7 +524,6 @@ pub struct ctlpaneltype {
     pub keyB2: u8,
 }
 
-pub static mut ch: i8 = 0;
 pub static mut playermode: [inputtype; 3] = [keyboard, keyboard, joystick1];
 pub static mut keydown: [boolean; 512] = [0; 512];
 pub static mut JoyXlow: [i32; 3] = [0; 3];
@@ -1788,8 +1787,8 @@ pub unsafe fn _checkhighscore(gs: &mut GlobalState, pas: &mut PcrlibAState) {
         j = 0;
         loop {
             k = get(gs, pas);
-            ch = k as i8;
-            if ch as i32 >= ' ' as i32 && j < 3 {
+            let ch = k as i8;
+            if ch >= ' ' as i8 && j < 3 {
                 drawchar(sx, sy, ch as i32, gs);
                 sx += 1;
                 highscores[i as usize].initials[j as usize] = ch;

--- a/src/pcrlib_c.rs
+++ b/src/pcrlib_c.rs
@@ -1756,7 +1756,8 @@ pub unsafe fn _showhighscores(gs: &mut GlobalState) {
         let str = CString::new(format!("{highscore}")).unwrap();
         print(str.as_ptr(), gs);
         sx += 1;
-        let str = CString::new(highscores[i as usize].initials.map(|f| f as u8)).unwrap();
+        // Rust port: Watch out! Entries includes the cstring terminator, which we must skip!
+        let str = CString::new(&highscores[i as usize].initials.map(|f| f as u8)[0..=2]).unwrap();
         print(str.as_ptr(), gs);
         let str = CString::new("\n\n").unwrap();
         print(str.as_ptr(), gs);

--- a/src/pcrlib_c.rs
+++ b/src/pcrlib_c.rs
@@ -953,18 +953,7 @@ pub fn LoadDemo(mut demonum: i32, gs: &mut GlobalState) {
     }
 }
 
-pub unsafe fn SaveDemo(mut demonum: i32, gs: &mut GlobalState) {
-    let str = CString::new(format!("DEMO{demonum}.{port_temp__extension}")).unwrap();
-
-    SaveFile(
-        str.as_ptr(),
-        demobuffer.as_ptr() as *const i8,
-        demoptr as i64,
-    );
-    gs.indemo = demoenum::notdemo;
-}
-
-pub unsafe fn port_temp_SaveDemo(demonum: u8, gs: &mut GlobalState) {
+pub unsafe fn SaveDemo(demonum: u8, gs: &mut GlobalState) {
     let str = format!("DEMO{demonum}.{port_temp__extension}");
 
     port_temp_SaveFile(&str, &demobuffer[..demoptr]);


### PR DESCRIPTION
Most significant:

- [x] Fix bug in highscore display (conversion to CString)
- [x] Replace SaveDemo() routine with safe version
- [x] Add port_temp_SaveFile()
- [x] Convert `demoptr` to usize (index), from raw pointer
- [x] Convert `ch` from global to local, and cautiously convert comparison literals to `i8` (from `i32`)